### PR TITLE
Fix PDF build

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -262,6 +262,14 @@ latex_elements = {
      # Latex figure (float) alignment
      #
      # 'figure_align': 'htbp',
+'fncychap': r'\usepackage[Conny]{fncychap}',
+'preamble': r'''
+\renewcommand{\thechapter}{}
+\renewcommand{\FmN}[1]{}
+\setcounter{chapter}{-1}
+\setcounter{secnumdepth}{0}
+\renewcommand{\numberline}[1]{}
+''',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/source/conf.py
+++ b/source/conf.py
@@ -265,6 +265,8 @@ latex_elements = {
      \setcounter{chapter}{-1}
      \setcounter{secnumdepth}{0}
      \renewcommand{\numberline}[1]{}
+     \fancypagestyle{normal}{
+     }
      ''',
 
      # Latex figure (float) alignment

--- a/source/conf.py
+++ b/source/conf.py
@@ -266,6 +266,7 @@ latex_elements = {
      \setcounter{secnumdepth}{0}
      \renewcommand{\numberline}[1]{}
      \fancypagestyle{normal}{
+          \fancyfoot[LO,RE]{\nouppercase{\rightmark}}
      }
      ''',
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -247,6 +247,8 @@ htmlhelp_basename = 'LearningVuFind'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
+     'fncychap': r'\usepackage[Conny]{fncychap}',
+
      # The paper size ('letterpaper' or 'a4paper').
      #
      # 'papersize': 'letterpaper',
@@ -257,19 +259,17 @@ latex_elements = {
 
      # Additional stuff for the LaTeX preamble.
      #
-     # 'preamble': '',
+     'preamble': r'''
+     \renewcommand{\thechapter}{}
+     \renewcommand{\FmN}[1]{}
+     \setcounter{chapter}{-1}
+     \setcounter{secnumdepth}{0}
+     \renewcommand{\numberline}[1]{}
+     ''',
 
      # Latex figure (float) alignment
      #
      # 'figure_align': 'htbp',
-'fncychap': r'\usepackage[Conny]{fncychap}',
-'preamble': r'''
-\renewcommand{\thechapter}{}
-\renewcommand{\FmN}[1]{}
-\setcounter{chapter}{-1}
-\setcounter{secnumdepth}{0}
-\renewcommand{\numberline}[1]{}
-''',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,9 +6,6 @@
 Welcome to Learning VuFind!
 ===========================
 
-Contents:
-#########
-
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
This PR is designed to fix the project so that `make latexpdf` generates a properly-formatted PDF version of the book that we can use as part of an official release.

TODO
- [x] Remove duplicate "CONTENTS" header
- [x] Eliminate the "CHAPTER ONE," "CHAPTER TWO," etc., large headings at the top of each section, because they are numbered inconsistently with the in-text PART numbers. (Or, if we can figure out how to leave the PREFACE unnumbered, and switch "CHAPTER" to "PART" in the auto-generated headings, that might help too).
- [x] Fix duplicate numbering -- currently, autogenerated section numbers are conflicting with in-text section numbers, resulting in things like "2.1.2 1.1 What is (and isn't) VuFind?".
- [x] Make sure headers and footers contain appropriate information.
- [x] Double-check that HTML version is still valid once PDF meets requirements.

Deferred TODO (out of scope for now)

- Fix internal hard-coded section number cross-references; is there a way to replace these with auto-generated numbers, so if we expand/reorganize the document in future, they will update correctly?
